### PR TITLE
Add reduced VAT rates in Germany

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -412,6 +412,44 @@
               "standard": 0
             }
           ]
+        },
+        {
+          "effective_from": "2020-07-01",
+          "rates": {
+            "reduced": 5,
+            "standard": 16
+          },
+          "exceptions": [
+            {
+              "name": "Büsingen am Hochrhein",
+              "postcode": "78266",
+              "standard": 0
+            },
+            {
+              "name": "Heligoland",
+              "postcode": "27498",
+              "standard": 0
+            }
+          ]
+        },
+        {
+          "effective_from": "2021-01-01",
+          "rates": {
+            "reduced": 7,
+            "standard": 19
+          },
+          "exceptions": [
+            {
+              "name": "Büsingen am Hochrhein",
+              "postcode": "78266",
+              "standard": 0
+            },
+            {
+              "name": "Heligoland",
+              "postcode": "27498",
+              "standard": 0
+            }
+          ]
         }
       ],
     "PT": [


### PR DESCRIPTION
From 2020-07-01 until 2020-12-31 there will be a reduced VAT rate in Germany.

Source: https://www.bundesregierung.de/breg-de/aktuelles/konjunkturpaket-1757482

I guess the exceptions will still apply, so I just added them as before.