### PR TITLE
Update rates for Ireland (Sept - Feb)

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -136,6 +136,26 @@
             "standard": 23,
             "parking": 13.5
           }
+        },
+        {
+          "effective_from": "2020-09-01",
+          "rates": {
+            "super_reduced": 4.8,
+            "reduced1": 9,
+            "reduced2": 13.5,
+            "standard": 21,
+            "parking": 13.5
+          }
+        }
+        {
+          "effective_from": "2021-03-01",
+          "rates": {
+            "super_reduced": 4.8,
+            "reduced1": 9,
+            "reduced2": 13.5,
+            "standard": 23,
+            "parking": 13.5
+          }
         }
       ],
     "SE":[


### PR DESCRIPTION
Announced in the end of July supposedly, but I only just found out. IE rate to drop from 23 to 21% from Sept 1st 2020 (tomorrow!) through Feb 28 2021.

Sources:

- https://www.revenue.ie/en/corporate/communications/stimulus/reduction-in-the-standard-rate-of-vat.aspx
- https://www.avalara.com/vatlive/en/vat-news/ireland-cuts-vat-from-23--to-21--till-feb-2021.html
- https://home.kpmg/ie/en/home/insights/2020/07/preparing-for-the-vat-rate-change-july-stimulus-package.html
- https://taxnews.ey.com/news/2020-1953-ireland-announces-temporary-reduction-in-vat-rate-as-part-of-july-2020-stimulus-plan
