### PR TITLE
Remove GB from vat-rates.json

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -74,6 +74,13 @@
             "standard": 20,
             "reduced": 5
           }
+        },
+        {
+          "effective_from": "2021-01-01",
+          "rates": {
+            "standard": 0,
+            "reduced": 0
+          }
         }
       ],
     "CZ":  [


### PR DESCRIPTION
GB is no longer part of the EU.

closes #8 