### PR TITLE
Update Luxemburg VAT rates for 2023

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -198,6 +198,24 @@
       ],
     "LU": [
         {
+          "effective_from": "2024-01-01",
+          "rates": {
+            "super_reduced": 3,
+            "reduced1": 8,
+            "standard": 17,
+            "parking": 13
+          }
+        },
+        {
+          "effective_from": "2023-01-01",
+          "rates": {
+            "super_reduced": 3,
+            "reduced1": 7,
+            "standard": 16,
+            "parking": 13
+          }
+        },
+        {
           "effective_from": "2016-01-01",
           "rates": {
             "super_reduced": 3,


### PR DESCRIPTION
On Jan 1st, Luxembourg cut the VAT rate by 1% to combat inflation. This lasts until the end of the year.

Official source (French): https://legilux.public.lu/eli/etat/leg/loi/2022/10/26/a534/jo

First article translated:

> By way of derogation from article 39, paragraph 3, of the amended law of 12 February 1979 concerning value added tax, the **normal** rate of value added tax is set at **sixteen percent**, the **reduced** rate is set at **seven percent** and the intermediate rate is set at thirteen percent of the tax base established in accordance with the provisions of Articles 28 to 38 of the said law, **for the period from January 1, 2023 to December 31, 2023 inclusive**.