### PR TITLE
Estonia: increase standard to 22% in 2024 and reduced to 13% in 2025

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -273,6 +273,20 @@
       ],
     "EE": [
         {
+          "effective_from": "2025-01-01",
+          "rates": {
+            "reduced": 13,
+            "standard": 22
+          }
+        },
+        {
+          "effective_from": "2024-01-01",
+          "rates": {
+            "reduced": 9,
+            "standard": 22
+          }
+        },
+        {
           "effective_from": "0000-01-01",
           "rates": {
             "reduced": 9,


### PR DESCRIPTION
https://www.vatcalc.com/estonia/estonia-raises-vat-to-22-1-january-2024/