### PR TITLE
The "parking" VAT rate for LU as of 2024-01-01 is incorrect

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -203,7 +203,7 @@
           "super_reduced": 3,
           "reduced1": 8,
           "standard": 17,
-          "parking": 13
+          "parking": 14
         }
       },
       {


### PR DESCRIPTION
The parking vat rate of 13% that was applicable in 2023, should be reverted back to the originel 14% that was used before. All other VAT rates have been reverted as of 2024-01-01 in the JSON file, but the parking vat rate was not updated.

See also:
- Official government page indicating that the 13% rate was valid until 2023-12-31: https://gouvernement.lu/en/actualites/toutes_actualites/communiques/2022/12-decembre/31-nouveautes-2023.html
- Numerous other resources indicating the 13% should revert to 14% as of 2024-01-01: https://www.globalvatcompliance.com/globalvatnews/luxembourg-standard-vat-rates-2024/