### PR TITLE
Greece uses two reduced vat rates of 6% and 13%

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -300,7 +300,7 @@
         "effective_from": "2016-06-01",
         "rates": {
           "reduced1": 6,
-          "reduced2": 13.5,
+          "reduced2": 13,
           "standard": 24
         },
         "exceptions": [


### PR DESCRIPTION
See also: https://taxation-customs.ec.europa.eu/document/download/28091aa6-62e0-4b27-922c-4f701e2f0ce3_en?filename=vat_rates_en.pdf