### PR TITLE
Additional EU vat rate fixes

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -285,7 +285,7 @@
         "effective_from": "2024-01-01",
         "rates": {
           "reduced": 9,
-          "standard": 22
+          "standard": 20
         }
       },
       {

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -80,7 +80,8 @@
       {
         "effective_from": "0000-01-01",
         "rates": {
-          "reduced": 15,
+          "reduced1": 10,
+          "reduced2": 15,
           "standard": 21
         }
       }

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -52,7 +52,8 @@
       {
         "effective_from": "0000-01-01",
         "rates": {
-          "reduced": 12,
+          "reduced1": 5,
+          "reduced2": 12,
           "standard": 21
         }
       }

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -287,7 +287,7 @@
         "effective_from": "2024-01-01",
         "rates": {
           "reduced": 9,
-          "standard": 20
+          "standard": 22
         }
       },
       {

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -124,7 +124,8 @@
       {
         "effective_from": "0000-01-01",
         "rates": {
-          "reduced": 9.5,
+          "reduced1": 5,
+          "reduced2": 9.5,
           "standard": 22
         }
       }


### PR DESCRIPTION
After posting a few PR's, (#15, #14, #13) I took the liberty to quickly check some of the other listings and found a few more minor issues: 

- [CZ uses two reduced rates of 10% and 15% instead of only 15%](https://github.com/ibericode/vat-rates/commit/44099e857ba95ef59bac5a5d66b10d836143b988)
- [Estonia uses a standard rate of 20%](https://github.com/ibericode/vat-rates/commit/a3569827992b2769d35c22b18e55a575c914a184)
- [Latvia uses two reduced rates of 5% and 12%](https://github.com/ibericode/vat-rates/commit/371cdc46717e8b45cd03ede83cafc568a7202954)
- [Slovenia uses two reduced vat rates of 5% and 9.5%](https://github.com/ibericode/vat-rates/commit/1c38ab71619cc9766cf619b886c4cb11fe187ab9)

I used the EU VAT PDF overview as reference: https://taxation-customs.ec.europa.eu/document/download/28091aa6-62e0-4b27-922c-4f701e2f0ce3_en?filename=vat_rates_en.pdf