### PR TITLE
Increase standard rate for Finland starting September '24

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -182,19 +182,19 @@
     ],
     "FI": [
       {
-        "effective_from": "0000-01-01",
-        "rates": {
-          "reduced1": 10,
-          "reduced2": 14,
-          "standard": 24
-        }
-      },
-      {
         "effective_from": "2024-09-01",
         "rates": {
           "reduced1": 10,
           "reduced2": 14,
           "standard": 25.5
+        }
+      },
+      {
+        "effective_from": "0000-01-01",
+        "rates": {
+          "reduced1": 10,
+          "reduced2": 14,
+          "standard": 24
         }
       }
     ],

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -188,6 +188,14 @@
           "reduced2": 14,
           "standard": 24
         }
+      },
+      {
+        "effective_from": "2024-09-01",
+        "rates": {
+          "reduced1": 10,
+          "reduced2": 14,
+          "standard": 25.5
+        }
       }
     ],
     "CY": [


### PR DESCRIPTION
As announced previously, but without definitive timeline, the standard VAT rate for Finland will increase from 24 to 25.5%. It looks like this timeline is now definitive according to many news sources:

- https://yle.fi/a/74-20091421
- https://www.roschier.com/newsroom/finnish-vat-rate-to-increase-to-25-5-starting-september-2024
- https://www.vatcalc.com/finland/finland-increases-vat-to-24-january-2013/ (ignore this slug 🤣)
- And many others

I'm not a Finnish resident and have some troubles to find a 100% definitive source confirming this, but the [draft budget](https://vm.fi/en/-/minister-of-finance-riikka-purra-s-draft-budget-for-2025) from the ministry of finance does mention it:

> The standard value-added tax rate and the rate of tax on certain insurance premiums will be raised from the current 24 per cent to 25.5 per cent. The increase will come into effect on 1 September 2024. The value-added tax rate for sweets will be raised from 14 per cent to the new standard value-added tax rate of 25.5 per cent as of 1 June 2025.

So I think it's safe to assume this can be implemented.

Resolves https://github.com/ibericode/vat-rates/issues/17