### PR TITLE
SK VAT rates valid from 2025

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -465,10 +465,17 @@
         }
       },
       {
-        "effective_from": "0000-01-01",
+        "effective_from": "2011-01-01",
         "rates": {
           "reduced": 10,
           "standard": 20
+        }
+      },
+      {
+        "effective_from": "0000-01-01",
+        "rates": {
+          "reduced": 10,
+          "standard": 19
         }
       }
     ],

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -459,7 +459,8 @@
       {
         "effective_from": "2025-01-01",
         "rates": {
-          "reduced": 19,
+          "reduced1": 5,
+          "reduced2": 19,
           "standard": 23
         }
       },


### PR DESCRIPTION
Slovakia will have 2 reduced VAT rates from 1.1.2025 according to this law
https://www.financnasprava.sk/_img/pfsedit/Dokumenty_PFS/Zverejnovanie_dok/Sprievodca/Sprievodca_danami/2024/2024.01.04_DPH_%202024.pdf

Unfortunately it's still not mentioned here
https://europa.eu/youreurope/business/taxation/vat/vat-rules-rates/index_en.htm
https://www.slovensko.sk/en/life-situation/life-situation/_value-added-tax