### PR TITLE
Add press_publications vat rate for Estonia

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -294,6 +294,7 @@
       {
         "effective_from": "2025-01-01",
         "rates": {
+          "press_publications": 9,
           "reduced": 13,
           "standard": 22
         }


### PR DESCRIPTION
As of 1st of January 2025, the Estonian government will increase the VAT rate for press publications from 5% to 9%. As it's only for press / publications and it was not in there in 2024, I've added a new category.

https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01012025

Coming up; there is also a coalition agreement to temporary increase standard VAT rate from 22% to 24% on 1st of July 2025, however this has not been put into law yet. 