### PR TITLE
Add second reduced rate (9% as of 2025) for Estonia

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -294,14 +294,16 @@
       {
         "effective_from": "2025-01-01",
         "rates": {
-          "reduced": 13,
+          "reduced1": 9,
+          "reduced2": 13,
           "standard": 22
         }
       },
       {
         "effective_from": "2024-01-01",
         "rates": {
-          "reduced": 9,
+          "reduced1": 5,
+          "reduced2": 9,
           "standard": 22
         }
       },


### PR DESCRIPTION
According to the VAT Act, [VAT rates in Estonia are 22%, 9%, 5% and 0%](https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax/vat-rates-and-supply-exempt-tax#:~:text=According%20to%20the%20VAT%20Act%2C,22%25%2C%209%25%2C%205%25%20and%200%25).

The reduced rates [will rise from 5% to 9% and from 9% to 13% respectively](https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01012025), starting January 1st, 2025.

The lower reduced rate (9% as of 2025) applies to press publications only.