### PR TITLE
Include VAT rates for non-EU territories

### DIFF
--- a/validate.py
+++ b/validate.py
@@ -8,7 +8,7 @@ class SchemaTest(unittest.TestCase):
     def test(self):
         file = open('vat-rates.json')
         data = json.load(file)
-        self.assertEqual(len(data['items']), 28)
+        self.assertEqual(len(data['items']), 30)
 
         for country, periods in data['items'].items():
             self.assertEqual(type(country), str)

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -411,6 +411,34 @@
         }
       }
     ],
+    "MC": [
+      {
+        "effective_from": "2014-01-01",
+        "rates": {
+          "super_reduced": 2.1,
+          "reduced1": 5.5,
+          "reduced2": 10,
+          "standard": 20
+        }
+      },
+      {
+        "effective_from": "2012-01-01",
+        "rates": {
+          "super_reduced": 2.1,
+          "reduced1": 5.5,
+          "reduced2": 7,
+          "standard": 19.6
+        }
+      },
+      {
+        "effective_from": "0000-01-01",
+        "rates": {
+          "super_reduced": 2.1,
+          "reduced1": 5.5,
+          "standard": 19.6
+        }
+      }
+    ],
     "HR": [
       {
         "effective_from": "0000-01-01",

--- a/vat-rates.json
+++ b/vat-rates.json
@@ -169,6 +169,38 @@
         }
       }
     ],
+    "XI": [
+      {
+        "effective_from": "2021-03-01",
+        "rates": {
+          "super_reduced": 4.8,
+          "reduced1": 9,
+          "reduced2": 13.5,
+          "standard": 23,
+          "parking": 13.5
+        }
+      },
+      {
+        "effective_from": "2020-09-01",
+        "rates": {
+          "super_reduced": 4.8,
+          "reduced1": 9,
+          "reduced2": 13.5,
+          "standard": 21,
+          "parking": 13.5
+        }
+      },
+      {
+        "effective_from": "0000-01-01",
+        "rates": {
+          "super_reduced": 4.8,
+          "reduced1": 9,
+          "reduced2": 13.5,
+          "standard": 23,
+          "parking": 13.5
+        }
+      }
+    ],
     "SE": [
       {
         "effective_from": "0000-01-01",


### PR DESCRIPTION
Some countries are not considered EU territories, but are considered EU with regards to VAT. Include VAT values for those (Northern Ireland and Monaco).

See the following sources for a full list of territorial exceptions and how to handle them:

- https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/zakelijk/btw/zakendoen_met_het_buitenland/goederen_en_diensten_naar_andere_eu_landen/eu-landen_en_-gebieden/ 
- https://www.belastingdienst.nl/wps/wcm/connect/bldcontentnl/belastingdienst/douane_voor_bedrijven/naslagwerken_en_overige_informatie/overzicht_eu_landen_eva_landen/overzicht_eu_landen/uitzonderingsgebieden/
- https://taxation-customs.ec.europa.eu/system/files/2021-06/vat_rates_en.pdf (chapter VII)

I think it makes sense to copy the values including history from the parent countries into separate entries. It can then be up to the application whether to query the parent country (FR in case of MC, IE in case of XI) or to query these rates directly.

For Monaco, VAT rates should be regarded as if the goods or services were supplied to France. For Northern Ireland this is similar for goods, but _not_ for services. However, I think that's also up to the application to consider, not this raw list of rates.

