### PR TITLE
Updated VAT rate for Estonia

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -292,6 +292,13 @@
     ],
     "EE": [
       {
+        "effective_from": "2025-07-01",
+        "rates": {
+          "reduced": 13,
+          "standard": 24
+        }
+      },
+      {
         "effective_from": "2025-01-01",
         "rates": {
           "reduced": 13,


### PR DESCRIPTION
According to multiple sources, VAT rate in Estonia has increased starting Jul. '01 2025:

- [https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01072025](https://www.emta.ee/en/business-client/taxes-and-payment/value-added-tax#from-01072025)
- [https://www.riigikogu.ee/tegevus/eelnoud/eelnou/e661c725-e0f9-4cea-b02c-02c385e9f0ac/ettevotlustulu-lihtsustatud-maksustamise-seaduse-julgeolekumaksu-seaduse-ja-tulumaksuseaduse-muutmise-seadus/](https://www.riigikogu.ee/tegevus/eelnoud/eelnou/e661c725-e0f9-4cea-b02c-02c385e9f0ac/ettevotlustulu-lihtsustatud-maksustamise-seaduse-julgeolekumaksu-seaduse-ja-tulumaksuseaduse-muutmise-seadus/)
- [https://www.globalvatcompliance.com/globalvatnews/estonia-vat-income-tax-increase/](https://www.globalvatcompliance.com/globalvatnews/estonia-vat-income-tax-increase/)