### PR TITLE
Update Romania VAT rates

### DIFF
--- a/vat-rates.json
+++ b/vat-rates.json
@@ -266,6 +266,13 @@
     ],
     "RO": [
       {
+        "effective_from": "2025-08-01",
+        "rates": {
+          "reduced": 11,
+          "standard": 21
+        }
+      },
+      {
         "effective_from": "2017-01-01",
         "rates": {
           "reduced1": 5,


### PR DESCRIPTION
Romanian VAT Rate Changes by August 2025

Romania Increases VAT Rates by August 2025.

- Standard VAT rate increases from 19% to 21%.
- A new reduced VAT rate of 11% will apply, replacing most of the current 5% and 9% rates.
- Only two VAT rates will remain: 21% (standard) and 11% (reduced).

Closes #29 